### PR TITLE
fix: share backtest state across widgets

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { create } from "zustand";
 import { TimePoint, Metrics, SeriesMap } from "./types";
 


### PR DESCRIPTION
## Summary
- mark backtest store as a client module so zustand state is shared

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9096ffda0832fa0c7213ce35c30f1