### PR TITLE
Modernize dashboard theme and layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,11 +2,11 @@ import Widget from "@/components/Widget";
 
 export default function Dashboard() {
   return (
-    <main className="p-4 grid grid-cols-3 grid-rows-3 gap-4 h-screen bg-black text-green-400 font-mono">
+    <main className="grid min-h-screen grid-cols-1 auto-rows-fr gap-4 p-4 md:grid-cols-3">
       <Widget defaultModule="inputs" />
       <Widget defaultModule="price" />
       <Widget defaultModule="metrics" />
-      <Widget defaultModule="portfolio" className="col-span-3" />
+      <Widget defaultModule="portfolio" className="md:col-span-3" />
       <Widget defaultModule="dividends" />
       <Widget defaultModule="tax" />
     </main>

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -77,7 +77,7 @@ export default function Controls() {
   return (
     <form onSubmit={handleSubmit} className="mb-4 flex flex-col gap-2">
       <textarea
-        className="border p-2 h-24 bg-black text-green-400"
+        className="h-24 w-full rounded border border-neutral-700 bg-neutral-800 p-2 text-neutral-100"
         value={tickers}
         onChange={(e) => setInputs({ tickers: e.target.value })}
       />
@@ -86,7 +86,7 @@ export default function Controls() {
           Capital
           <input
             type="number"
-            className="border p-1 bg-black text-green-400"
+            className="rounded border border-neutral-700 bg-neutral-800 p-1 text-neutral-100"
             value={initialCapital}
             onChange={(e) =>
               setInputs({ initialCapital: Number(e.target.value) })
@@ -97,7 +97,7 @@ export default function Controls() {
           Monthly
           <input
             type="number"
-            className="border p-1 bg-black text-green-400"
+            className="rounded border border-neutral-700 bg-neutral-800 p-1 text-neutral-100"
             value={monthlyDeposit}
             onChange={(e) =>
               setInputs({ monthlyDeposit: Number(e.target.value) })
@@ -109,7 +109,7 @@ export default function Controls() {
           <input
             type="number"
             step={0.1}
-            className="border p-1 bg-black text-green-400"
+            className="rounded border border-neutral-700 bg-neutral-800 p-1 text-neutral-100"
             value={leverage}
             onChange={(e) =>
               setInputs({ leverage: Number(e.target.value) })
@@ -138,13 +138,16 @@ export default function Controls() {
         </p>
       </div>
       <div className="flex gap-2">
-        <button type="submit" className="bg-green-700 text-black px-4 py-2">
+        <button
+          type="submit"
+          className="rounded bg-blue-600 px-4 py-2 text-white"
+        >
           Run
         </button>
         <button
           type="button"
           onClick={exportCsv}
-          className="bg-gray-700 text-green-400 px-4 py-2"
+          className="rounded bg-gray-700 px-4 py-2 text-white"
         >
           Export CSV
         </button>

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -62,13 +62,13 @@ export default function Widget({
 
   return (
     <div
-      className={`border p-2 bg-black text-green-400 font-mono h-full ${className}`}
+      className={`h-full rounded-lg border border-neutral-700 bg-neutral-800 p-4 text-neutral-100 ${className}`}
     >
-      <div className="flex justify-end mb-2">
+      <div className="mb-2 flex justify-end">
         <select
           value={module}
           onChange={(e) => setModule(e.target.value as ModuleKey)}
-          className="bg-black text-green-400 border"
+          className="rounded border border-neutral-600 bg-neutral-700 p-1 text-neutral-100"
         >
           {options.map((o) => (
             <option key={o.value} value={o.value}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,26 +1,12 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --background: #1b1b1b;
+  --foreground: #f5f5f5;
 }
 
 body {
-  background: #000;
-  color: #00ff00;
-  font-family: "Courier New", monospace;
+  background-color: var(--background);
+  color: var(--foreground);
+  font-family: system-ui, sans-serif;
 }


### PR DESCRIPTION
## Summary
- apply dark neutral global theme
- revamp widget and controls with rounded neutral styling
- restructure dashboard grid for mobile-first layout

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba429f53e0832f9ab5f7946b95b9d4