### PR TITLE
feat: add margin analysis

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import PortfolioCharts from '@/components/PortfolioCharts';
+import MarginAnalysis from '@/components/MarginAnalysis';
 
 export default function HomePage() {
   const [tickers, setTickers] = useState('');
@@ -13,6 +14,8 @@ export default function HomePage() {
     portfolio: { date: string; value: number }[];
     weeklyDividends: { week: string; amount: number }[];
     taxes: { date: string; amount: number }[];
+    margin: { date: string; loan: number; cash: number }[];
+    marginCalls: { date: string }[];
   }
   const [data, setData] = useState<PortfolioResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -97,12 +100,13 @@ export default function HomePage() {
       </form>
       {loading && <p className="text-center mt-4">Loading...</p>}
       {data && (
-        <div className="mt-8">
+        <div className="mt-8 space-y-8">
           <PortfolioCharts
             portfolio={data.portfolio}
             weeklyDividends={data.weeklyDividends}
             taxes={data.taxes}
           />
+          <MarginAnalysis margin={data.margin} marginCalls={data.marginCalls} />
         </div>
       )}
     </main>

--- a/components/MarginAnalysis.tsx
+++ b/components/MarginAnalysis.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from 'recharts';
+
+interface Props {
+  margin: { date: string; loan: number; cash: number }[];
+  marginCalls: { date: string }[];
+}
+
+export default function MarginAnalysis({ margin, marginCalls }: Props) {
+  return (
+    <div className="space-y-4">
+      <div className="h-64 w-full">
+        <ResponsiveContainer>
+          <LineChart data={margin}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" hide />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="loan" stroke="#b91c1c" name="Margin Loan" />
+            <Line type="monotone" dataKey="cash" stroke="#0ea5e9" name="Cash" />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      {marginCalls.length > 0 && (
+        <div>
+          <h3 className="font-semibold">Margin Calls</h3>
+          <ul className="list-disc pl-5">
+            {marginCalls.map((m) => (
+              <li key={m.date}>{m.date}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- compute margin loan and cash balances over time with 25% maintenance requirement and leverage capped at 1.75x
- display margin loan, cash, and margin call dates via new MarginAnalysis component
- integrate margin analysis into main dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bac97ae688832f811d2632e3e5a87b