### PR TITLE
Add UEC tracking and clarify chart assumptions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,7 @@ export default function HomePage() {
     portfolio: { date: string; value: number }[];
     weeklyDividends: { week: string; amount: number }[];
     taxes: { date: string; amount: number }[];
-    margin: { date: string; loan: number; cash: number }[];
+    margin: { date: string; loan: number; cash: number; uec: number }[];
     marginCalls: { date: string }[];
   }
   const [data, setData] = useState<PortfolioResponse | null>(null);

--- a/components/MarginAnalysis.tsx
+++ b/components/MarginAnalysis.tsx
@@ -11,7 +11,7 @@ import {
 } from 'recharts';
 
 interface Props {
-  margin: { date: string; loan: number; cash: number }[];
+  margin: { date: string; loan: number; cash: number; uec: number }[];
   marginCalls: { date: string }[];
 }
 
@@ -27,9 +27,14 @@ export default function MarginAnalysis({ margin, marginCalls }: Props) {
             <Tooltip />
             <Line type="monotone" dataKey="loan" stroke="#b91c1c" name="Margin Loan" />
             <Line type="monotone" dataKey="cash" stroke="#0ea5e9" name="Cash" />
+            <Line type="monotone" dataKey="uec" stroke="#047857" name="UEC Value" />
           </LineChart>
         </ResponsiveContainer>
       </div>
+      <p className="text-sm text-gray-600">
+        Assumes dividends reduce margin loans and 75% of received cash is reinvested at 1.75x
+        leverage while 25% remains as cash equity.
+      </p>
       {marginCalls.length > 0 && (
         <div>
           <h3 className="font-semibold">Margin Calls</h3>

--- a/components/PortfolioCharts.tsx
+++ b/components/PortfolioCharts.tsx
@@ -32,6 +32,10 @@ export default function PortfolioCharts({ portfolio, weeklyDividends, taxes }: P
           </LineChart>
         </ResponsiveContainer>
       </div>
+      <p className="text-sm text-gray-600">
+        Assumes 75% of available cash is deployed at 1.75x leverage with a 25% cash
+        reserve.
+      </p>
       <div className="h-64 w-full">
         <ResponsiveContainer>
           <BarChart data={weeklyDividends}>
@@ -43,6 +47,10 @@ export default function PortfolioCharts({ portfolio, weeklyDividends, taxes }: P
           </BarChart>
         </ResponsiveContainer>
       </div>
+      <p className="text-sm text-gray-600">
+        Weekly dividend totals are reinvested at 1.75x leverage while 25% remains as
+        cash equity.
+      </p>
       <div className="h-64 w-full">
         <ResponsiveContainer>
           <BarChart data={taxes}>
@@ -54,6 +62,9 @@ export default function PortfolioCharts({ portfolio, weeklyDividends, taxes }: P
           </BarChart>
         </ResponsiveContainer>
       </div>
+      <p className="text-sm text-gray-600">
+        Taxes assume a flat 15% rate applied to dividends on the payment date.
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Track total UEC value alongside margin loan and cash
- Reinvest dividends and monthly contributions with 75% equity at 1.75x leverage, keeping 25% cash
- Document key assumptions under each chart

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bacf8333ac832fae4e6ca0ac77f456