### PR TITLE
feat: enhance margin analysis with prices and month-end logic

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ export default function HomePage() {
     taxes: { date: string; amount: number }[];
     margin: { date: string; loan: number; cash: number; uec: number }[];
     dividends: { date: string; amount: number }[];
+    prices?: { date: string; [ticker: string]: number }[];
   }
   const [data, setData] = useState<PortfolioResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -106,7 +107,7 @@ export default function HomePage() {
             weeklyDividends={data.weeklyDividends}
             taxes={data.taxes}
           />
-          <MarginAnalysis margin={data.margin} dividends={data.dividends} />
+          <MarginAnalysis margin={data.margin} dividends={data.dividends} prices={data.prices} />
         </div>
       )}
     </main>


### PR DESCRIPTION
## Summary
- overhaul margin analysis to reset positions at month-end, pay down loans, and re-lever to 75% equity with dual EOM snapshots
- add optional daily price inputs with dynamic table columns and CSV export
- expose per-day prices from the portfolio API and pass them through the UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb214d14c8832f91367be7c4a512c4