### PR TITLE
Expand margin analysis and add options tracker

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import PortfolioCharts from '@/components/PortfolioCharts';
 import MarginAnalysis from '@/components/MarginAnalysis';
+import OptionsPositions, { OptionPosition } from '@/components/OptionsPositions';
 
 export default function HomePage() {
   const [tickers, setTickers] = useState('');
@@ -17,6 +18,7 @@ export default function HomePage() {
     margin: { date: string; loan: number; cash: number; uec: number }[];
     dividends: { date: string; amount: number }[];
     prices?: { date: string; [ticker: string]: number | string }[];
+    optionsPositions?: OptionPosition[];
   }
   const [data, setData] = useState<PortfolioResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -108,6 +110,7 @@ export default function HomePage() {
             taxes={data.taxes}
           />
           <MarginAnalysis margin={data.margin} dividends={data.dividends} prices={data.prices} />
+          <OptionsPositions positions={data.optionsPositions ?? []} />
         </div>
       )}
     </main>

--- a/components/MarginAnalysis.tsx
+++ b/components/MarginAnalysis.tsx
@@ -15,88 +15,102 @@ import {
 } from 'recharts';
 
 type MarginSnap = { date: string; loan: number; cash: number; uec: number };
-type Dividend   = { date: string; amount: number };
-type CashFlow   = { date: string; amount: number; note?: string };
-
-/** Row shape for prices: each item is { date, TICKER1: price, TICKER2: price, ... }  */
+type Dividend = { date: string; amount: number };
+type CashFlow = { date: string; amount: number; note?: string };
 type PriceRow = { date: string; [ticker: string]: number | string };
 
 interface Props {
   margin: MarginSnap[];
   dividends?: Dividend[];
   cashFlows?: CashFlow[];
-
-  /** Optional per-day price table. Example: [{date:'2025-01-01', SPY: 480.2, QQQ: 410.3}] */
   prices?: PriceRow[];
-
-  /** Knobs */
-  maintenanceRatio?: number;     // e.g., 0.25
-  interestAPR?: number;          // e.g., 0.08
-  interestDayCount?: number;     // 365 by default
-  /** Target to borrow (equity basis) after month-end reset. 0.75 => loan = 75% of equity */
-  borrowTargetPct?: number;      // default 0.75
-
-  /** Keep two rows on month-end: pre actions (D) and post actions (EOM). */
-  showDualMonthEndRows?: boolean; // default true
+  maintenanceRatio?: number;
+  interestAPR?: number;
+  interestDayCount?: number;
+  borrowTargetPct?: number;
+  showDualMonthEndRows?: boolean;
 }
 
-type Stage = 'D' | 'EOM'; // Daily snapshot vs. Month-end post-actions
+type Stage = 'D' | 'EOM';
 
 type SimRow = MarginSnap & {
-  stage: Stage;             // 'D' pre EOM, 'EOM' post-reset & re-lever
-  mv: number;               // cash + uec
-  equity: number;           // mv - loan
-  equityEconomic: number;   // equity - accrued interest MTD
-  mr: number;               // maintenance requirement ($)
-  buffer: number;           // equity - mr
-  usagePct: number;         // loan / mv
-  equityRatio: number;      // equity / mv
+  stage: Stage;
+  mv: number;
+  equity: number;
+  mr: number;
+  buffer: number;
+  usagePct: number;
+  equityRatio: number;
   monthEnd: boolean;
 
-  // Cash/div/interest & flows
-  div: number;              // dividend today
+  priceRet?: number;
+  pricePnL?: number;
+  priceMTD?: number;
+  priceYTD?: number;
+
+  navDeltaDaily?: number;
+  navDeltaMTD?: number;
+  navDeltaYTD?: number;
+  navDecayUserDaily?: boolean;
+  navDecayUserMTD?: boolean;
+  navDecayUserYTD?: boolean;
+
+  ppiIndex?: number;
+  ptriIndex?: number;
+  triRet?: number;
+
+  priceCAGR90?: number;
+  triCAGR90?: number;
+  navDecayFlag?: boolean;
+
+  div: number;
   divMTD: number;
   divYTD: number;
-  flow: number;             // deposit(+)/withdraw(-) today
-  interestDaily: number;    // interest accrued today
-  interestMTD: number;      // accrued (unsettled) this month
-  interestYTD: number;      // accrued YTD
+  flow: number;
+  interestDaily: number;
+  interestMTD: number;
+  interestYTD: number;
 
-  // Capacity & calls
-  borrowCapacity: number;   // L_max - loan (for display)
+  borrowCapacity: number;
   hadCall: boolean;
   callCashNeeded?: number;
   callSellNeeded?: number;
 
-  // Month-end mechanics audit
-  eomLiquidationProceeds?: number; // amount moved from uec -> cash
-  eomLoanPaydown?: number;         // loan repayment from cash
-  eomShortfall?: number;           // if loan couldn't be fully repaid
-  eomBorrowToTarget?: number;      // new borrow to hit target
+  rv20d?: number;
+  sigmaDollar?: number;
+  lossToCallDollar?: number;
+  lossToCallPctMV?: number;
+  daysToCallAt1Sigma?: number;
+
+  eomLiquidationProceeds?: number;
+  eomLoanPaydown?: number;
+  eomShortfall?: number;
+  eomBorrowToTarget?: number;
   eomTargetLoan?: number;
 
-  // Performance metrics
   romMonthly?: number | null;
   rom30d?: number | null;
 
-  // Optional per-day quote map for tickers
   prices?: Record<string, number>;
+  _mvRet?: number; // internal helper for rolling variance
 };
 
 function getYMD(d: string) {
   const x = new Date(d + 'T00:00:00');
   return { y: x.getUTCFullYear(), m: x.getUTCMonth(), d: x.getUTCDate() };
 }
-
 function fmt(n?: number) {
   if (n === undefined || Number.isNaN(n)) return '-';
   return n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
 }
+function num(n?: number, d = 2) {
+  if (n === undefined || Number.isNaN(n)) return '-';
+  return n.toLocaleString('en-US', { maximumFractionDigits: d });
+}
 function pct(n?: number) {
   if (n === undefined || Number.isNaN(n)) return '-';
-  return `${(n * 100).toFixed(1)}%`;
+  return `${(n * 100).toFixed(2)}%`;
 }
-
 function SummaryCard({ label, value, danger = false }: { label: string; value: string; danger?: boolean }) {
   return (
     <div className={`p-2 rounded shadow bg-white text-center ${danger ? 'text-red-600' : 'text-slate-700'}`}>
@@ -117,29 +131,25 @@ export default function MarginAnalysis({
   borrowTargetPct = 0.75,
   showDualMonthEndRows = true,
 }: Props) {
-  // Map: date -> total dividend
   const dividendMap = React.useMemo(() => {
     const m = new Map<string, number>();
     for (const d of dividends) m.set(d.date, (m.get(d.date) ?? 0) + d.amount);
     return m;
   }, [dividends]);
 
-  // Map: date -> net cash flow
   const flowMap = React.useMemo(() => {
     const m = new Map<string, number>();
     for (const f of cashFlows) m.set(f.date, (m.get(f.date) ?? 0) + f.amount);
     return m;
   }, [cashFlows]);
 
-  // Map: date -> {ticker: price,...} and list of tickers (dynamic columns)
   const { priceMap, priceTickers } = React.useMemo(() => {
     const pMap = new Map<string, Record<string, number>>();
     let tickers: string[] = [];
     for (const r of prices) {
       const cleaned: Record<string, number> = {};
-      const restObj = r as Record<string, unknown>;
-      for (const k of Object.keys(restObj)) {
-        const v = restObj[k];
+      const entries = Object.entries(r) as [string, unknown][];
+      for (const [k, v] of entries) {
         if (k !== 'date' && typeof v === 'number') cleaned[k] = v;
       }
       pMap.set(r.date, cleaned);
@@ -150,15 +160,11 @@ export default function MarginAnalysis({
 
   const sim = React.useMemo<SimRow[]>(() => {
     if (!margin || margin.length === 0) return [];
-
     const base = [...margin].sort((a, b) => a.date.localeCompare(b.date));
-
-    // Evolving state
     let loan = base[0].loan;
     let cash = base[0].cash;
-    let uec  = base[0].uec;
+    let uec = base[0].uec;
 
-    // Month/Year trackers
     let monthAccDiv = 0;
     let monthStartEquity = uec + cash - loan;
     let monthLoanSum = 0;
@@ -169,44 +175,62 @@ export default function MarginAnalysis({
     let yearAccDiv = 0;
     let yearInterestAccrued = 0;
 
+    let pricePnL_MTD = 0;
+    let pricePnL_YTD = 0;
+
+    let ppi = 100;
+    let ptri = 100;
+
     const rows: SimRow[] = [];
     const lastIdx = base.length - 1;
 
     for (let i = 0; i < base.length; i++) {
       const snap = base[i];
       const ym = getYMD(snap.date);
+      const nextYM = i < lastIdx ? getYMD(base[i + 1].date) : null;
+      const isMonthEnd = !nextYM || nextYM.m !== ym.m || nextYM.y !== ym.y;
+
       if (ym.y !== currentYear) {
         currentYear = ym.y;
         yearAccDiv = 0;
         yearInterestAccrued = 0;
+        pricePnL_YTD = 0;
       }
 
-      // 1) Apply price-only return from baseline uec series (on whatever uec we currently hold)
+      const uecStart = uec;
+      let priceRet = 0;
       if (i > 0) {
         const prev = base[i - 1].uec;
         const curr = base[i].uec;
-        const ret = prev > 0 ? curr / prev - 1 : 0;
-        uec = uec * (1 + ret);
+        priceRet = prev > 0 ? curr / prev - 1 : 0;
+        uec = uec * (1 + priceRet);
       } else {
         uec = base[0].uec;
       }
+      const pricePnL = uecStart * priceRet;
+      pricePnL_MTD += pricePnL;
+      pricePnL_YTD += pricePnL;
 
-      // 2) Dividends → reduce loan first, excess to cash
-      const div = dividendMap.get(snap.date) ?? 0;
+      ppi = ppi * (1 + priceRet);
+      const divToday = dividendMap.get(snap.date) ?? 0;
+      const divYield = uecStart > 0 ? divToday / uecStart : 0;
+      const triRet = priceRet + Math.max(0, divYield);
+      ptri = ptri * (1 + triRet);
+
+      const div = divToday;
       if (div > 0) {
         const pay = Math.min(div, loan);
         loan -= pay;
         const leftover = div - pay;
         if (leftover > 0) cash += leftover;
         monthAccDiv += div;
-        yearAccDiv  += div;
+        yearAccDiv += div;
       }
 
-      // 3) Deposits / Withdrawals
       const flow = flowMap.get(snap.date) ?? 0;
       if (flow !== 0) {
         if (flow > 0) {
-          cash += flow; // deposit
+          cash += flow;
         } else {
           const w = -flow;
           if (cash >= w) {
@@ -214,63 +238,64 @@ export default function MarginAnalysis({
           } else {
             const short = w - cash;
             cash = 0;
-            loan += short; // borrow to fund withdrawal
+            loan += short;
           }
         }
       }
 
-      // 4) Accrue daily interest (charged at month-end)
       let interestDaily = 0;
       if (loan > 0 && interestAPR > 0) {
         const dailyRate = interestAPR / (interestDayCount || 365);
         interestDaily = loan * dailyRate;
         monthInterestAccrued += interestDaily;
-        yearInterestAccrued  += interestDaily;
+        yearInterestAccrued += interestDaily;
       }
 
-      // 5) Diagnostics (pre month-end)
-      const mvPre = Math.max(uec + cash, 0);
-      const equityPre = mvPre - loan;
-      const mrPre = maintenanceRatio * mvPre;
-      const bufferPre = equityPre - mrPre;
-      const usagePctPre = mvPre > 0 ? loan / mvPre : 0;
-      const equityRatioPre = mvPre > 0 ? equityPre / mvPre : 1;
-      const hadCallPre = bufferPre < 0;
+      const mv = Math.max(uec + cash, 0);
+      const equity = mv - loan;
+      const mr = maintenanceRatio * mv;
+      const buffer = equity - mr;
+      const usagePct = mv > 0 ? loan / mv : 0;
+      const equityRatio = mv > 0 ? equity / mv : 1;
+      const hadCall = buffer < 0;
+      const callCashNeeded = hadCall ? mr - equity : 0;
+      const callSellNeeded = hadCall ? (mr - equity) / maintenanceRatio : 0;
+      const lMax = Math.max(0, equity * (1 / maintenanceRatio - 1));
+      const borrowCapacity = Math.max(0, lMax - loan);
 
-      const callCashNeeded = hadCallPre ? mrPre - equityPre : 0;
-      const callSellNeeded = hadCallPre ? (mrPre - equityPre) / maintenanceRatio : 0;
+      const navDeltaDaily = (pricePnL ?? 0) + (div ?? 0);
+      const navDeltaMTD = (pricePnL_MTD ?? 0) + (monthAccDiv ?? 0);
+      const navDeltaYTD = (pricePnL_YTD ?? 0) + (yearAccDiv ?? 0);
+      const navDecayUserDaily = navDeltaDaily < 0;
+      const navDecayUserMTD = navDeltaMTD < 0;
+      const navDecayUserYTD = navDeltaYTD < 0;
 
-      // Capacity (display)
-      const lMaxPre = Math.max(0, equityPre * (1 / maintenanceRatio - 1));
-      const borrowCapacityPre = Math.max(0, lMaxPre - loan);
-
-      // Month boundary?
-      const nextYM = i < lastIdx ? getYMD(base[i + 1].date) : null;
-      const isMonthEnd = !nextYM || nextYM.m !== ym.m || nextYM.y !== ym.y;
-
-      // Track averages
-      monthLoanSum += loan;
-      monthLoanDays += 1;
-
-      // Economic equity subtracts accrued (unsettled) interest
-      const equityEconomicPre = equityPre - monthInterestAccrued;
-
-      // --- Push DAILY (pre EOM) row ---
-      const pricesToday = priceMap.get(snap.date) || undefined;
-      const dailyRow: SimRow = {
+      rows.push({
         stage: 'D',
         date: snap.date,
         loan,
         cash,
         uec,
-        mv: mvPre,
-        equity: equityPre,
-        equityEconomic: equityEconomicPre,
-        mr: mrPre,
-        buffer: bufferPre,
-        usagePct: usagePctPre,
-        equityRatio: equityRatioPre,
+        mv,
+        equity,
+        mr,
+        buffer,
+        usagePct,
+        equityRatio,
         monthEnd: isMonthEnd,
+        priceRet,
+        pricePnL,
+        priceMTD: pricePnL_MTD,
+        priceYTD: pricePnL_YTD,
+        ppiIndex: ppi,
+        ptriIndex: ptri,
+        triRet,
+        navDeltaDaily,
+        navDeltaMTD,
+        navDeltaYTD,
+        navDecayUserDaily,
+        navDecayUserMTD,
+        navDecayUserYTD,
         div,
         divMTD: monthAccDiv,
         divYTD: yearAccDiv,
@@ -278,67 +303,48 @@ export default function MarginAnalysis({
         interestDaily,
         interestMTD: monthInterestAccrued,
         interestYTD: yearInterestAccrued,
-        borrowCapacity: borrowCapacityPre,
-        hadCall: hadCallPre,
-        callCashNeeded: hadCallPre ? Math.max(0, callCashNeeded) : undefined,
-        callSellNeeded: hadCallPre ? Math.max(0, callSellNeeded) : undefined,
+        borrowCapacity,
+        hadCall,
+        callCashNeeded: hadCall ? Math.max(0, callCashNeeded) : undefined,
+        callSellNeeded: hadCall ? Math.max(0, callSellNeeded) : undefined,
         romMonthly: null,
         rom30d: null,
-        prices: pricesToday,
-      };
-      rows.push(dailyRow);
+        prices: priceMap.get(snap.date) || undefined,
+      });
 
-      // Rolling 30-row ROM using economic equity
-      if (rows.length >= 31) {
-        const idx = rows.length - 1;
-        const prior = rows[idx - 30];
-        const pnl30 = rows[idx].equityEconomic - prior.equityEconomic;
-        const slice = rows.slice(idx - 29, idx + 1);
-        const avgLoan30 = slice.reduce((s, r) => s + r.loan, 0) / slice.length || 0;
-        rows[idx].rom30d = avgLoan30 !== 0 ? pnl30 / Math.abs(avgLoan30) : 0;
-      }
-
-      // === Month-end actions: SELL ALL → PAY LOAN → RE-LEVER TO TARGET (equity basis) ===
       if (isMonthEnd) {
-        // A) Settle interest first (reduces cash or increases loan)
         if (monthInterestAccrued > 0) {
           if (cash >= monthInterestAccrued) {
             cash -= monthInterestAccrued;
           } else {
             const short = monthInterestAccrued - cash;
             cash = 0;
-            loan += short; // capitalize unpaid interest
+            loan += short;
           }
         }
 
-        // B) Liquidate all securities
         const liquidationProceeds = uec;
         cash += liquidationProceeds;
         uec = 0;
 
-        // C) Pay down loan fully from cash (if possible)
         const loanPaydown = Math.min(loan, cash);
         loan -= loanPaydown;
         cash -= loanPaydown;
-        const shortfall = loan > 0 ? loan : 0; // if > 0, still under water
+        const shortfall = loan > 0 ? loan : 0;
 
-        // D) Re-lever from clean slate (equity = cash - loan)
         const equityNow = Math.max(0, cash - loan);
         const targetLoan = Math.max(0, borrowTargetPct * equityNow);
         let borrowed = 0;
         if (targetLoan > loan) {
-          borrowed = targetLoan - loan; // usually = targetLoan if loan==0
+          borrowed = targetLoan - loan;
           loan += borrowed;
-          uec += borrowed;             // buy securities with borrowed funds only
+          uec += borrowed;
         } else if (targetLoan < loan) {
-          // Shouldn't happen after payoff, but keep symmetry to be safe:
           const repay = Math.min(loan - targetLoan, cash);
           loan -= repay;
           cash -= repay;
-          // If still above target and no cash, we could sell UEC, but you specified sell-all only at month-end.
         }
 
-        // Post diagnostics
         const mvPost = Math.max(uec + cash, 0);
         const equityPost = mvPost - loan;
         const mrPost = maintenanceRatio * mvPost;
@@ -346,7 +352,6 @@ export default function MarginAnalysis({
         const usagePctPost = mvPost > 0 ? loan / mvPost : 0;
         const equityRatioPost = mvPost > 0 ? equityPost / mvPost : 1;
 
-        // Month ROM (computed on post-action snapshot)
         const monthEndEquity = equityPost;
         const pnl = monthEndEquity - monthStartEquity;
         const avgLoan = monthLoanDays > 0 ? monthLoanSum / monthLoanDays : 0;
@@ -361,12 +366,24 @@ export default function MarginAnalysis({
             uec,
             mv: mvPost,
             equity: equityPost,
-            equityEconomic: equityPost, // after settlement, economic==accounting
             mr: mrPost,
             buffer: bufferPost,
             usagePct: usagePctPost,
             equityRatio: equityRatioPost,
             monthEnd: true,
+            priceRet: 0,
+            pricePnL: 0,
+            priceMTD: 0,
+            priceYTD: pricePnL_YTD,
+            ppiIndex: ppi,
+            ptriIndex: ptri,
+            triRet: 0,
+            navDeltaDaily: 0,
+            navDeltaMTD: 0,
+            navDeltaYTD: pricePnL_YTD + yearAccDiv,
+            navDecayUserDaily: false,
+            navDecayUserMTD: false,
+            navDecayUserYTD: (pricePnL_YTD + yearAccDiv) < 0,
             div: 0,
             divMTD: 0,
             divYTD: yearAccDiv,
@@ -376,121 +393,171 @@ export default function MarginAnalysis({
             interestYTD: yearInterestAccrued,
             borrowCapacity: Math.max(0, Math.max(0, equityPost * (1 / maintenanceRatio - 1)) - loan),
             hadCall: bufferPost < 0,
-            romMonthly: rom,
-            rom30d: null,
+            callCashNeeded: undefined,
+            callSellNeeded: undefined,
             eomLiquidationProceeds: liquidationProceeds,
             eomLoanPaydown: loanPaydown,
             eomShortfall: shortfall || undefined,
             eomBorrowToTarget: borrowed || undefined,
             eomTargetLoan: targetLoan,
+            romMonthly: rom,
+            rom30d: null,
             prices: priceMap.get(snap.date) || undefined,
-            callCashNeeded: undefined,
-            callSellNeeded: undefined,
           });
         } else {
-          // If not showing dual rows, attach ROM to the pre row
           rows[rows.length - 1].romMonthly = rom;
         }
 
-        // Reset month trackers
         monthAccDiv = 0;
         monthInterestAccrued = 0;
         monthStartEquity = monthEndEquity;
         monthLoanSum = 0;
         monthLoanDays = 0;
+        pricePnL_MTD = 0;
+      }
+
+      monthLoanSum += loan;
+      monthLoanDays += 1;
+    }
+
+    const dIdx: number[] = [];
+    for (let i = 0; i < rows.length; i++) if (rows[i].stage === 'D') dIdx.push(i);
+
+    for (let i = 0; i < dIdx.length; i++) {
+      const idx = dIdx[i];
+      if (i >= 30) {
+        const i0 = dIdx[i - 30];
+        const eq0 = rows[i0].equity;
+        const eq1 = rows[idx].equity;
+        const pnl30 = eq1 - eq0;
+        const avgLoan = rows.slice(i0, idx + 1).reduce((s, r) => s + (r.loan || 0), 0) / 31;
+        rows[idx].rom30d = avgLoan !== 0 ? pnl30 / Math.abs(avgLoan) : 0;
+      }
+    }
+
+    for (let k = 1; k < dIdx.length; k++) {
+      const i1 = dIdx[k], i0 = dIdx[k - 1];
+      const r = rows[i1];
+      const prev = rows[i0];
+      const mvRet = prev.mv > 0 ? r.mv / prev.mv - 1 : 0;
+      r._mvRet = mvRet;
+    }
+    const m = maintenanceRatio;
+    for (let k = 0; k < dIdx.length; k++) {
+      const i1 = dIdx[k];
+      const start = Math.max(0, k - 19);
+      const slice = dIdx.slice(start, k + 1).map(i => rows[i]._mvRet ?? 0);
+      const mean = slice.reduce((s, x) => s + x, 0) / (slice.length || 1);
+      const var_ = slice.reduce((s, x) => s + (x - mean) ** 2, 0) / (slice.length > 1 ? (slice.length - 1) : 1);
+      const rv20d = Math.sqrt(Math.max(0, var_));
+      const r = rows[i1];
+      r.rv20d = rv20d;
+      r.sigmaDollar = (r.mv || 0) * (rv20d || 0);
+      const buffer = r.buffer || 0;
+      const lossToCallDollar = buffer > 0 ? buffer / (1 - m) : 0;
+      r.lossToCallDollar = lossToCallDollar;
+      r.lossToCallPctMV = r.mv > 0 ? lossToCallDollar / r.mv : undefined;
+      r.daysToCallAt1Sigma = (r.sigmaDollar || 0) > 0 ? lossToCallDollar / (r.sigmaDollar || 1) : undefined;
+    }
+
+    const annFactor = (n: number) => (n > 1 ? 252 / n : 0);
+    const dRows = dIdx.map(i => rows[i]);
+    for (let k = 0; k < dRows.length; k++) {
+      const end = dRows[k];
+      const startK = Math.max(0, k - 89);
+      const startRow = dRows[startK];
+      const n = k - startK;
+      if (n > 0 && startRow.ppiIndex && end.ppiIndex && startRow.ptriIndex && end.ptriIndex) {
+        const ppiCAGR = Math.pow(end.ppiIndex! / startRow.ppiIndex!, annFactor(n)) - 1;
+        const triCAGR = Math.pow(end.ptriIndex! / startRow.ptriIndex!, annFactor(n)) - 1;
+        end.priceCAGR90 = ppiCAGR;
+        end.triCAGR90 = triCAGR;
+        end.navDecayFlag = ppiCAGR < 0 && triCAGR >= 0;
+      }
+    }
+
+    const dailyByDate = new Map<string, SimRow>();
+    for (const r of rows) if (r.stage === 'D') dailyByDate.set(r.date, r);
+    for (const r of rows) {
+      if (r.stage === 'EOM') {
+        const d = dailyByDate.get(r.date);
+        if (d) {
+          r.rv20d = d.rv20d;
+          r.sigmaDollar = d.sigmaDollar;
+          r.lossToCallDollar = d.lossToCallDollar;
+          r.lossToCallPctMV = d.lossToCallPctMV;
+          r.daysToCallAt1Sigma = d.daysToCallAt1Sigma;
+          r.rom30d = d.rom30d;
+          r.priceCAGR90 = d.priceCAGR90;
+          r.triCAGR90 = d.triCAGR90;
+          r.navDecayFlag = d.navDecayFlag;
+          r.ppiIndex = d.ppiIndex;
+          r.ptriIndex = d.ptriIndex;
+          r.navDeltaDaily = d.navDeltaDaily;
+          r.navDeltaMTD = d.navDeltaMTD;
+          r.navDeltaYTD = d.navDeltaYTD;
+          r.navDecayUserDaily = d.navDecayUserDaily;
+          r.navDecayUserMTD = d.navDecayUserMTD;
+          r.navDecayUserYTD = d.navDecayUserYTD;
+        }
       }
     }
 
     return rows;
   }, [
     margin,
-    dividendMap,
-    flowMap,
-    priceMap,
-    maintenanceRatio,
-    interestAPR,
-    interestDayCount,
-    borrowTargetPct,
-    showDualMonthEndRows,
+    maintenanceRatio, interestAPR, interestDayCount, borrowTargetPct, showDualMonthEndRows,
+    dividendMap, flowMap, priceMap
   ]);
 
-  // For charts, show the post-EOM snapshot instead of the pre-EOM daily one.
-  const simForCharts = React.useMemo(
-    () => sim.filter(r => !(r.monthEnd && r.stage === 'D')),
-    [sim]
-  );
-
+  const simForCharts = React.useMemo(() => sim.filter(r => !(r.monthEnd && r.stage === 'D')), [sim]);
   const marginCalls = React.useMemo(
-    () => sim.filter((r) => r.hadCall).map((r) => ({
+    () => sim.filter(r => r.hadCall).map(r => ({
       date: r.date + (r.stage === 'EOM' ? ' (EOM)' : ''),
       callCashNeeded: r.callCashNeeded ?? 0,
       callSellNeeded: r.callSellNeeded ?? 0,
       buffer: r.buffer,
     })), [sim]
   );
-
   const latest = simForCharts.at(-1);
 
-  // === CSV Export ===
   const handleExportCSV = React.useCallback(() => {
     if (!sim.length) return;
-
     const baseCols = [
       'date','stage','cash','uec','mv','loan','equity','mr','buffer','usagePct','equityRatio',
       'div','divMTD','divYTD','flow','interestDaily','interestMTD','interestYTD',
-      'borrowCapacity','rom30d','romMonthly',
-      'eomLiquidationProceeds','eomLoanPaydown','eomShortfall','eomBorrowToTarget','eomTargetLoan'
+      'priceRet','pricePnL','priceMTD','priceYTD','ppiIndex','ptriIndex','triRet',
+      'navDeltaDaily','navDeltaMTD','navDeltaYTD','navDecayUserDaily','navDecayUserMTD','navDecayUserYTD',
+      'rv20d','sigmaDollar','lossToCallDollar','lossToCallPctMV','daysToCallAt1Sigma',
+      'rom30d','romMonthly','eomLiquidationProceeds','eomLoanPaydown','eomShortfall','eomBorrowToTarget','eomTargetLoan',
+      'priceCAGR90','triCAGR90','navDecayFlag'
     ];
-
-    const cols = [...baseCols, ...priceTickers.map(t => `price:${t}`)];
-
-    const rows = sim.map(r => {
-      const rec: Record<string, string | number> = {
-        date: r.date,
-        stage: r.stage,
-        cash: r.cash ?? '',
-        uec: r.uec ?? '',
-        mv: r.mv ?? '',
-        loan: r.loan ?? '',
-        equity: r.equity ?? '',
-        mr: r.mr ?? '',
-        buffer: r.buffer ?? '',
-        usagePct: r.usagePct ?? '',
-        equityRatio: r.equityRatio ?? '',
-        div: r.div ?? '',
-        divMTD: r.divMTD ?? '',
-        divYTD: r.divYTD ?? '',
-        flow: r.flow ?? '',
-        interestDaily: r.interestDaily ?? '',
-        interestMTD: r.interestMTD ?? '',
-        interestYTD: r.interestYTD ?? '',
-        borrowCapacity: r.borrowCapacity ?? '',
-        rom30d: r.rom30d ?? '',
-        romMonthly: r.romMonthly ?? '',
-        eomLiquidationProceeds: r.eomLiquidationProceeds ?? '',
-        eomLoanPaydown: r.eomLoanPaydown ?? '',
-        eomShortfall: r.eomShortfall ?? '',
-        eomBorrowToTarget: r.eomBorrowToTarget ?? '',
-        eomTargetLoan: r.eomTargetLoan ?? '',
-      };
-      for (const t of priceTickers) {
-        rec[`price:${t}`] = r.prices?.[t] ?? '';
-      }
-      return rec;
-    });
-
-    const csv = [
-      cols.join(','),
-      ...rows.map(row =>
-        cols.map(k => {
-          const v = (row as Record<string, string | number | undefined>)[k];
-          if (v === null || v === undefined) return '';
-          const s = String(v);
-          return s.includes(',') || s.includes('"') ? `"${s.replace(/"/g, '""')}"` : s;
-        }).join(',')
-      )
-    ].join('\n');
-
+    const priceTickers = sim.reduce<string[]>((acc, r) => {
+      const ks = r.prices ? Object.keys(r.prices) : [];
+      for (const k of ks) if (!acc.includes(k)) acc.push(k);
+      return acc;
+    }, []);
+      const cols = [...baseCols, ...priceTickers.map(t => `price:${t}`)];
+      const rows = sim.map(r => {
+        const rec: Record<string, string | number | boolean> = {};
+        for (const k of baseCols) {
+          const v = (r as Record<string, unknown>)[k];
+          rec[k] = (v as string | number | boolean) ?? '';
+        }
+        for (const t of priceTickers) rec[`price:${t}`] = r.prices?.[t] ?? '';
+        return rec;
+      });
+      const csv = [
+        cols.join(','),
+        ...rows.map(row =>
+          cols.map(k => {
+            const v = row[k];
+            if (v === null || v === undefined) return '';
+            const s = String(v);
+            return s.includes(',') || s.includes('"') ? `"${s.replace(/"/g, '""')}"` : s;
+          }).join(',')
+        )
+      ].join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -500,11 +567,10 @@ export default function MarginAnalysis({
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  }, [sim, priceTickers]);
+  }, [sim]);
 
   return (
     <div className="space-y-6">
-      {/* Summary */}
       <div className="grid grid-cols-2 sm:grid-cols-6 gap-3">
         <SummaryCard label="Equity" value={fmt(latest?.equity)} />
         <SummaryCard label="Loan" value={fmt(latest?.loan)} />
@@ -514,7 +580,13 @@ export default function MarginAnalysis({
         <SummaryCard label="Maint. Buffer" value={fmt(latest?.buffer)} danger={!!latest && latest.buffer < 0} />
       </div>
 
-      {/* Dollar Chart (post-EOM snapshots) */}
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
+        <SummaryCard label="Price CAGR (90d ann.)" value={pct(latest?.priceCAGR90)} danger={(latest?.priceCAGR90 ?? 0) < 0} />
+        <SummaryCard label="TRI CAGR (90d ann.)" value={pct(latest?.triCAGR90)} danger={(latest?.triCAGR90 ?? 0) < 0} />
+        <SummaryCard label="PPI Index" value={num(latest?.ppiIndex, 2)} />
+        <SummaryCard label="TRI Index" value={num(latest?.ptriIndex, 2)} />
+      </div>
+
       <div className="h-72 w-full">
         <ResponsiveContainer>
           <LineChart data={simForCharts}>
@@ -535,7 +607,6 @@ export default function MarginAnalysis({
         </ResponsiveContainer>
       </div>
 
-      {/* Equity Ratio vs Maintenance (post-EOM snapshots) */}
       <div className="h-72 w-full">
         <ResponsiveContainer>
           <AreaChart data={simForCharts}>
@@ -549,7 +620,6 @@ export default function MarginAnalysis({
         </ResponsiveContainer>
       </div>
 
-      {/* Margin Calls */}
       {marginCalls.length > 0 && (
         <div>
           <h3 className="font-semibold">Margin Calls</h3>
@@ -563,7 +633,6 @@ export default function MarginAnalysis({
         </div>
       )}
 
-      {/* Controls */}
       <div className="flex items-center gap-3">
         <button
           onClick={handleExportCSV}
@@ -572,42 +641,68 @@ export default function MarginAnalysis({
           Export CSV
         </button>
         <span className="text-xs text-slate-500">
-          Month-end rule: sell all → pay loan → borrow {Math.round(borrowTargetPct*100)}% of equity → buy with borrowed only.
+          EOM rule: sell all → pay loan → borrow {Math.round(borrowTargetPct * 100)}% of equity → buy with borrowed only.
         </span>
       </div>
 
-      {/* Daily Ledger Table */}
       <div>
         <h3 className="font-semibold mb-2">Daily Ledger (pre and post month-end)</h3>
         <div className="overflow-x-auto overflow-y-auto max-h-[28rem] rounded border border-slate-200">
-          <table className="min-w-[1600px] w-full text-xs">
+          <table className="min-w-[2200px] w-full text-xs">
             <thead className="bg-slate-50 sticky top-0">
               <tr className="text-left">
                 <th className="p-2">Date</th>
                 <th className="p-2">Stage</th>
                 <th className="p-2 text-right">Cash</th>
                 <th className="p-2 text-right">UEC</th>
-                <th className="p-2 text-right">Market Value</th>
+                <th className="p-2 text-right">MV</th>
                 <th className="p-2 text-right">Loan</th>
                 <th className="p-2 text-right">Equity</th>
                 <th className="p-2 text-right">Maint ($)</th>
                 <th className="p-2 text-right">Buffer</th>
-                <th className="p-2 text-right">Equity Ratio</th>
+                <th className="p-2 text-right">Eq. Ratio</th>
                 <th className="p-2 text-right">Usage %</th>
-                <th className="p-2 text-right">Dividend</th>
+
+                <th className="p-2 text-right">Div</th>
                 <th className="p-2 text-right">Div MTD</th>
                 <th className="p-2 text-right">Div YTD</th>
                 <th className="p-2 text-right">Flow</th>
-                <th className="p-2 text-right">Interest (day)</th>
-                <th className="p-2 text-right">Interest MTD</th>
+                <th className="p-2 text-right">Int (day)</th>
+                <th className="p-2 text-right">Int MTD</th>
+
+                <th className="p-2 text-right">Price Ret</th>
+                <th className="p-2 text-right">Price P&amp;L</th>
+                <th className="p-2 text-right">Price MTD</th>
+                <th className="p-2 text-right">Price YTD</th>
+
+                <th className="p-2 text-right">PPI</th>
+                <th className="p-2 text-right">TRI</th>
+                <th className="p-2 text-right">Price CAGR 90d</th>
+                <th className="p-2 text-right">TRI CAGR 90d</th>
+                <th className="p-2 text-right">NAV Decay? (CAGR)</th>
+
+                <th className="p-2 text-right">NAV Δ (Daily)</th>
+                <th className="p-2 text-right">NAV Δ (MTD)</th>
+                <th className="p-2 text-right">NAV Δ (YTD)</th>
+                <th className="p-2 text-right">NAV Decay? (Daily)</th>
+                <th className="p-2 text-right">NAV Decay? (MTD)</th>
+                <th className="p-2 text-right">NAV Decay? (YTD)</th>
+
                 <th className="p-2 text-right">Borrow Cap</th>
-                <th className="p-2 text-right">Excess ROM (30d)</th>
-                <th className="p-2 text-right">ROM (Month)</th>
+                <th className="p-2 text-right">ROM 30d</th>
+
+                <th className="p-2 text-right">RV 20d</th>
+                <th className="p-2 text-right">σ$</th>
+                <th className="p-2 text-right">Loss→Call $</th>
+                <th className="p-2 text-right">Loss→Call %MV</th>
+                <th className="p-2 text-right">Days→Call @1σ</th>
+
                 <th className="p-2 text-right">EOM Proceeds</th>
                 <th className="p-2 text-right">EOM Loan Paydown</th>
                 <th className="p-2 text-right">EOM Shortfall</th>
                 <th className="p-2 text-right">EOM Borrowed</th>
                 <th className="p-2 text-right">EOM Target Loan</th>
+
                 {priceTickers.map(t => (
                   <th key={t} className="p-2 text-right">{t}</th>
                 ))}
@@ -627,20 +722,47 @@ export default function MarginAnalysis({
                   <td className={`p-2 text-right ${r.buffer < 0 ? 'text-red-600 font-semibold' : ''}`}>{fmt(r.buffer)}</td>
                   <td className="p-2 text-right">{pct(r.equityRatio)}</td>
                   <td className="p-2 text-right">{pct(r.usagePct)}</td>
+
                   <td className="p-2 text-right">{r.div ? fmt(r.div) : '-'}</td>
                   <td className="p-2 text-right">{r.divMTD ? fmt(r.divMTD) : '-'}</td>
                   <td className="p-2 text-right">{r.divYTD ? fmt(r.divYTD) : '-'}</td>
                   <td className="p-2 text-right">{r.flow ? fmt(r.flow) : '-'}</td>
                   <td className="p-2 text-right">{r.interestDaily ? fmt(r.interestDaily) : '-'}</td>
                   <td className="p-2 text-right">{r.interestMTD ? fmt(r.interestMTD) : '-'}</td>
+
+                  <td className="p-2 text-right">{r.priceRet !== undefined ? pct(r.priceRet) : '-'}</td>
+                  <td className="p-2 text-right">{r.pricePnL !== undefined ? fmt(r.pricePnL) : '-'}</td>
+                  <td className="p-2 text-right">{r.priceMTD !== undefined ? fmt(r.priceMTD) : '-'}</td>
+                  <td className="p-2 text-right">{r.priceYTD !== undefined ? fmt(r.priceYTD) : '-'}</td>
+
+                  <td className="p-2 text-right">{r.ppiIndex !== undefined ? num(r.ppiIndex, 2) : '-'}</td>
+                  <td className="p-2 text-right">{r.ptriIndex !== undefined ? num(r.ptriIndex, 2) : '-'}</td>
+                  <td className={`p-2 text-right ${((r.priceCAGR90 ?? 0) < 0) ? 'text-red-600' : ''}`}>{r.priceCAGR90 !== undefined ? pct(r.priceCAGR90) : '-'}</td>
+                  <td className={`p-2 text-right ${((r.triCAGR90 ?? 0) < 0) ? 'text-red-600' : ''}`}>{r.triCAGR90 !== undefined ? pct(r.triCAGR90) : '-'}</td>
+                  <td className={`p-2 text-right ${r.navDecayFlag ? 'text-amber-700 font-semibold' : ''}`}>{r.navDecayFlag ? 'Yes' : 'No'}</td>
+
+                  <td className={`p-2 text-right ${((r.navDeltaDaily ?? 0) < 0) ? 'text-amber-700 font-semibold' : ''}`}>{r.navDeltaDaily !== undefined ? fmt(r.navDeltaDaily) : '-'}</td>
+                  <td className={`p-2 text-right ${((r.navDeltaMTD ?? 0) < 0) ? 'text-amber-700 font-semibold' : ''}`}>{r.navDeltaMTD !== undefined ? fmt(r.navDeltaMTD) : '-'}</td>
+                  <td className={`p-2 text-right ${((r.navDeltaYTD ?? 0) < 0) ? 'text-amber-700 font-semibold' : ''}`}>{r.navDeltaYTD !== undefined ? fmt(r.navDeltaYTD) : '-'}</td>
+                  <td className={`p-2 text-right ${r.navDecayUserDaily ? 'text-amber-700 font-semibold' : ''}`}>{r.navDecayUserDaily ? 'Yes' : 'No'}</td>
+                  <td className={`p-2 text-right ${r.navDecayUserMTD ? 'text-amber-700 font-semibold' : ''}`}>{r.navDecayUserMTD ? 'Yes' : 'No'}</td>
+                  <td className={`p-2 text-right ${r.navDecayUserYTD ? 'text-amber-700 font-semibold' : ''}`}>{r.navDecayUserYTD ? 'Yes' : 'No'}</td>
+
                   <td className="p-2 text-right">{r.borrowCapacity ? fmt(r.borrowCapacity) : '-'}</td>
                   <td className="p-2 text-right">{r.rom30d !== null && r.rom30d !== undefined ? pct(r.rom30d) : '-'}</td>
-                  <td className="p-2 text-right">{r.romMonthly !== null && r.romMonthly !== undefined ? pct(r.romMonthly) : '-'}</td>
+
+                  <td className="p-2 text-right">{r.rv20d !== undefined ? pct(r.rv20d) : '-'}</td>
+                  <td className="p-2 text-right">{r.sigmaDollar !== undefined ? fmt(r.sigmaDollar) : '-'}</td>
+                  <td className="p-2 text-right">{r.lossToCallDollar !== undefined ? fmt(r.lossToCallDollar) : '-'}</td>
+                  <td className="p-2 text-right">{r.lossToCallPctMV !== undefined ? pct(r.lossToCallPctMV) : '-'}</td>
+                  <td className="p-2 text-right">{r.daysToCallAt1Sigma !== undefined ? num(r.daysToCallAt1Sigma, 2) : '-'}</td>
+
                   <td className="p-2 text-right">{r.eomLiquidationProceeds ? fmt(r.eomLiquidationProceeds) : '-'}</td>
                   <td className="p-2 text-right">{r.eomLoanPaydown ? fmt(r.eomLoanPaydown) : '-'}</td>
                   <td className={`p-2 text-right ${r.eomShortfall ? 'text-red-600' : ''}`}>{r.eomShortfall ? fmt(r.eomShortfall) : '-'}</td>
                   <td className="p-2 text-right">{r.eomBorrowToTarget ? fmt(r.eomBorrowToTarget) : '-'}</td>
                   <td className="p-2 text-right">{r.eomTargetLoan ? fmt(r.eomTargetLoan) : '-'}</td>
+
                   {priceTickers.map(t => (
                     <td key={`${r.date}-${r.stage}-${t}`} className="p-2 text-right">
                       {r.prices && typeof r.prices[t] === 'number' ? (r.prices[t] as number).toLocaleString() : '-'}
@@ -652,7 +774,7 @@ export default function MarginAnalysis({
           </table>
         </div>
         <p className="text-xs text-slate-500 mt-2">
-          EOM row shows: <em>sell all</em> → <em>pay loan</em> → <em>borrow {Math.round(borrowTargetPct*100)}% of equity</em> → <em>buy with borrowed only</em>.
+          Loss→Call $ = Buffer / (1 − {Math.round(maintenanceRatio * 100)}%). Days→Call @1σ ≈ Loss→Call $ / (MV × RV20d). Your NAV-decay rule flags when price loss exceeds dividends over Daily/MTD/YTD.
         </p>
       </div>
     </div>

--- a/components/OptionsPositions.tsx
+++ b/components/OptionsPositions.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import * as React from 'react';
+
+export interface OptionPosition {
+  symbol: string;
+  expiration: string; // YYYY-MM-DD
+  strike: number;
+  premium: number;
+  quantity: number;
+  type: 'PUT' | 'CALL';
+}
+
+function fmt(n?: number) {
+  if (n === undefined || Number.isNaN(n)) return '-';
+  return n.toLocaleString('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 });
+}
+
+function num(n?: number, d = 2) {
+  if (n === undefined || Number.isNaN(n)) return '-';
+  return n.toLocaleString('en-US', { maximumFractionDigits: d });
+}
+
+export default function OptionsPositions({ positions = [] }: { positions?: OptionPosition[] }) {
+  if (!positions.length) {
+    return (
+      <div>
+        <h3 className="font-semibold mb-2">Option Positions</h3>
+        <p className="text-sm text-slate-500">No option positions tracked.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h3 className="font-semibold mb-2">Option Positions</h3>
+      <div className="overflow-x-auto rounded border border-slate-200">
+        <table className="min-w-full text-xs">
+          <thead className="bg-slate-50">
+            <tr className="text-left">
+              <th className="p-2">Symbol</th>
+              <th className="p-2">Type</th>
+              <th className="p-2">Expiration</th>
+              <th className="p-2 text-right">Strike</th>
+              <th className="p-2 text-right">Premium</th>
+              <th className="p-2 text-right">Qty</th>
+              <th className="p-2 text-right">Total Premium</th>
+              <th className="p-2 text-right">Break-even</th>
+              <th className="p-2 text-right">Collateral</th>
+            </tr>
+          </thead>
+          <tbody>
+            {positions.map((p, idx) => {
+              const total = p.premium * 100 * p.quantity;
+              const breakEven = p.type === 'PUT' ? p.strike - p.premium : p.strike + p.premium;
+              const collateral = p.strike * 100 * p.quantity;
+              return (
+                <tr key={idx} className={idx % 2 ? 'bg-slate-50' : 'bg-white'}>
+                  <td className="p-2 whitespace-nowrap">{p.symbol}</td>
+                  <td className="p-2">{p.type}</td>
+                  <td className="p-2 whitespace-nowrap">{p.expiration}</td>
+                  <td className="p-2 text-right">{fmt(p.strike)}</td>
+                  <td className="p-2 text-right">{fmt(p.premium)}</td>
+                  <td className="p-2 text-right">{num(p.quantity, 0)}</td>
+                  <td className="p-2 text-right">{fmt(total)}</td>
+                  <td className="p-2 text-right">{fmt(breakEven)}</td>
+                  <td className="p-2 text-right">{fmt(collateral)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- overhaul MarginAnalysis with price/NAV tracking, volatility stats, and CSV export
- add OptionsPositions component for tracking option positions like sold puts
- wire OptionsPositions into main dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb586e6968832fbae78f5e507532b9